### PR TITLE
syntax errors thrown by render & compile functions are hard to debug

### DIFF
--- a/index.js
+++ b/index.js
@@ -333,6 +333,7 @@ var compile = exports.compile = function(str, options){
       err.message += options.filename
         ? ' in ' + filename
         : ' while compiling qejs';
+      err.source = str;
     }
     throw err;
   }


### PR DESCRIPTION
provide the generated code as a member of the error object in case of a SyntaxError
